### PR TITLE
Add script to use google vision to ocr pdf to txt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ key_file = '/home/key.json'
 pdf.split_and_ocr_on_drive(pdf_file, key_file)
 ```
 
+* Usage for the `google_vision_pdf.py` to OCR pdf to txt files.
+
+- Follow the instructions here: https://cloud.google.com/vision/docs/before-you-begin. Make sure
+to set the environment variable for `GOOGLE_APPLICATION_CREDENTIALS` to the path
+of json containing your service account key.
+    - Example:
+    ```
+    export GOOGLE_APPLICATION_CREDENTIALS="/home/user/Downloads/service-account-file.json"
+    ```
+
+- Invoke the script passing in the input file. Eg:
+
+```
+python3 google_vision_pdf.py --input-file <input.pdf>
+```
 
 # For contributors
 

--- a/doc_curation/pdf.py
+++ b/doc_curation/pdf.py
@@ -98,6 +98,7 @@ def split_into_small_pdfs(pdf_path, output_directory=None, start_page=1, end_pag
       end_page = len(pdf.pages)
     pages = range(start_page, end_page + 1)
     page_sets = list_helper.divide_chunks(list_in=pages, n=small_pdf_pages)
+    dest_pdfs = []
     for page_set in page_sets:
       pages = [pdf.pages[i - 1] for i in page_set]
       dest_pdf_path = os.path.join(output_directory, "%s_%04d-%04d.pdf" % (pdf_name_stem, page_set[0], page_set[-1]))
@@ -109,6 +110,8 @@ def split_into_small_pdfs(pdf_path, output_directory=None, start_page=1, end_pag
         dest_pdf.save(filename_or_stream=dest_pdf_path)
       else:
         logging.warning("%s exists", dest_pdf_path)
+      dest_pdfs.append(dest_pdf_path)
+  return dest_pdfs
 
 
 # Adapted from https://github.com/theeko74/pdfc/blob/master/pdf_compressor.py

--- a/google_vision_pdf.py
+++ b/google_vision_pdf.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# See: https://github.com/googleapis/python-vision/blob/master/samples/snippets/detect/detect.py
+
+import os
+import logging
+import io
+from pathlib import Path
+from pikepdf import Pdf
+import argparse
+from doc_curation import pdf as doc_curation_pdf
+from google.cloud import vision_v1
+from curation_utils import list_helper
+
+
+def sample_batch_annotate_files(file_path="path/to/your/document.pdf"):
+    """Perform batch file annotation."""
+    client = vision_v1.ImageAnnotatorClient()
+
+    # Supported mime_type: application/pdf, image/tiff, image/gif
+    mime_type = "application/pdf"
+    final_ocr_path = file_path + ".txt"
+    dest_pdfs = doc_curation_pdf.split_into_small_pdfs(pdf_path=file_path,
+                                                       small_pdf_pages=5, start_page=1, end_page=None)
+    file_out = io.open(file_path + ".txt", "w")
+    for dest_pdf in dest_pdfs:
+        with io.open(dest_pdf, "rb") as f:
+            content = f.read()
+        input_config = {"mime_type": mime_type, "content": content}
+        features = [{"type_": vision_v1.Feature.Type.DOCUMENT_TEXT_DETECTION}]
+
+        # The service can process up to 5 pages per document file. The splitting
+        # above ensures each file has not more than 5 pages
+        pages = [i + 1 for i in range(5)]
+        requests = [{"input_config": input_config, "features": features, "pages": pages}]
+
+        response = client.batch_annotate_files(requests=requests)
+        for image_response in response.responses[0].responses:
+            file_out.write(u"{}".format(image_response.full_text_annotation.text))
+    file_out.close()
+
+def main():
+    parser = argparse.ArgumentParser(description="OCR a PDF using google vision")
+    parser.add_argument("--input-file", help="input pdf file to be ocred", required=True,
+                        type=str)
+    args = parser.parse_args()
+    sample_batch_annotate_files(args.input_file)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Adds a script to use Google Vision APIs to OCR pdf to txt. Based on the example [here](https://github.com/googleapis/python-vision/blob/master/samples/snippets/detect/detect.py)
- I saw there was a solution using google vision already available [here](https://github.com/lalitaalaalitah/GoogleVisionOCR_Python), but it works only for images. Also, I wanted to reuse the splitting utilities already worked on this repo.
- Also adds a return for `split_into_small_pdfs` for `doc_curation/pdf.py`.